### PR TITLE
Users are being rate limited even if they make fewer requests

### DIFF
--- a/src/Throttlers/CacheThrottler.php
+++ b/src/Throttlers/CacheThrottler.php
@@ -95,9 +95,11 @@ class CacheThrottler implements ThrottlerInterface, Countable
      */
     public function hit()
     {
-        $this->number = $this->count() + 1;
-
-        $this->store->put($this->key, $this->number, $this->time);
+        if ($this->count()) {
+                $this->store->increment($this->key);
+        } else {
+                $this->store->put($this->key, 1, $this->time);
+        }
 
         return $this;
     }

--- a/src/Throttlers/CacheThrottler.php
+++ b/src/Throttlers/CacheThrottler.php
@@ -97,8 +97,10 @@ class CacheThrottler implements ThrottlerInterface, Countable
     {
         if ($this->count()) {
                 $this->store->increment($this->key);
+                $this->number++;
         } else {
                 $this->store->put($this->key, 1, $this->time);
+                $this->number = 1;
         }
 
         return $this;


### PR DESCRIPTION
Fixes a problem when users that are within rate limits are being rate limited.
Currently Cache:put() extends key lifetime indefinitelly if user does a request before key expires.

Using Cache::increment() only changes key's value and does't change expire time. We still need Cache::put() for storing initial key value and lifetime.

This pull requests passes all unit tests.