### PR TITLE
Enhance throttling logic

### DIFF
--- a/src/Factories/CacheFactory.php
+++ b/src/Factories/CacheFactory.php
@@ -50,7 +50,7 @@ class CacheFactory implements FactoryInterface
      */
     public function make(Data $data)
     {
-        return new CacheThrottler($this->cache->getStore(), $data->getKey(), $data->getLimit(), $data->getTime());
+        return new CacheThrottler($this->cache, $data->getKey(), $data->getLimit(), $data->getTime());
     }
 
     /**

--- a/src/Throttlers/CacheThrottler.php
+++ b/src/Throttlers/CacheThrottler.php
@@ -155,11 +155,20 @@ class CacheThrottler implements ThrottlerInterface, Countable
             $this->clear();
         }
 
+        if($this->limitRemainedTime() <= 0){
+            $this->clear();
+        }
+
         if($this->count() < $this->limit){
             return true;
         }
 
         return false;
+    }
+
+    protected function limitRemainedTime()
+    {
+        return ($this->time * 60) - (time() - $this->cache->get($this->key . ":" . $this->getFirstHitMarker()));
     }
 
     /**
@@ -203,13 +212,7 @@ class CacheThrottler implements ThrottlerInterface, Countable
             return 0;
         }
 
-        $remainedTime = ($this->time * 60) - (time() - $this->cache->get($this->key . ":" . $this->getFirstHitMarker()));
-
-        if($remainedTime < 0){
-            $this->clear();
-        }
-
-        return $remainedTime;
+        return $this->limitRemainedTime();
     }
 
     /**

--- a/src/Throttlers/ThrottlerInterface.php
+++ b/src/Throttlers/ThrottlerInterface.php
@@ -52,4 +52,18 @@ interface ThrottlerInterface
      * @return bool
      */
     public function check();
+
+    /**
+     * Get the number of seconds until the "$this->key" is accessible again.
+     *
+     * @return int
+     */
+    public function availableIn();
+
+    /**
+     * Get the number of retries left for the given key.
+     *
+     * @return int
+     */
+    public function retriesLeft();
 }


### PR DESCRIPTION
Hello
I think there is two scenarios for throttles:
1.	Limit access to a route, `$limit` times per `$time`. (for example : user can access application 3 times per 1 minute)
2.	Route access should block for `$time` minutes after each `$limit` requests. (for example : After processing 3 Requests, Route should be locked for 10 minutes. No matter how long it took to do that requests, Route Should be lockout 10 minutes after last successful request.)

As I know, your current package support none of this modes. Your application may be completely closed forever after first `$limit` requests. For example when you set `$limit = 3` and `$time = 1` minute, your application will be locked after 3 requests. If you stop requesting application will be automatically starts responding after 1 minute, but if you continue requesting application, after each time hit count will be increased and cache item will be renewed. So the cache will not ever expired and then system will be locked forever. 
But in my edit, I implement scenario 1. I set a mark on first request for $time minutes. If user reach the limit while that mark is alive the request will be refused. When mark deads, the hit count will be cleared and throttling will be starts over. 
And of course I create 2 more methods to provide some facilities about throttling:
1.	`availableIn()` : When route locked this method returns amount of seconds remained until route be available again.
2.	`retriesLeft()` : returns number of remained retries.

Thank you…

