### PR TITLE
Crated TransformerFactoryInterface, and now Throttle constructor acce…

### DIFF
--- a/src/Throttle.php
+++ b/src/Throttle.php
@@ -13,6 +13,7 @@ namespace GrahamCampbell\Throttle;
 
 use GrahamCampbell\Throttle\Factories\FactoryInterface;
 use GrahamCampbell\Throttle\Transformers\TransformerFactory;
+use GrahamCampbell\Throttle\Transformers\TransformerFactoryInterface;
 
 /**
  * This is the throttle class.
@@ -52,11 +53,11 @@ class Throttle
      * Create a new instance.
      *
      * @param \GrahamCampbell\Throttle\Factories\FactoryInterface      $factory
-     * @param \GrahamCampbell\Throttle\Transformers\TransformerFactory $transformer
+     * @param \GrahamCampbell\Throttle\Transformers\TransformerFactoryInterface $transformer
      *
      * @return void
      */
-    public function __construct(FactoryInterface $factory, TransformerFactory $transformer)
+    public function __construct(FactoryInterface $factory, TransformerFactoryInterface $transformer)
     {
         $this->factory = $factory;
         $this->transformer = $transformer;

--- a/src/ThrottleServiceProvider.php
+++ b/src/ThrottleServiceProvider.php
@@ -14,6 +14,7 @@ namespace GrahamCampbell\Throttle;
 use GrahamCampbell\Throttle\Factories\CacheFactory;
 use GrahamCampbell\Throttle\Factories\FactoryInterface;
 use GrahamCampbell\Throttle\Transformers\TransformerFactory;
+use GrahamCampbell\Throttle\Transformers\TransformerFactoryInterface;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Foundation\Application as LaravelApplication;
 use Illuminate\Support\ServiceProvider;
@@ -95,6 +96,7 @@ class ThrottleServiceProvider extends ServiceProvider
         });
 
         $this->app->alias('throttle.transformer', TransformerFactory::class);
+        $this->app->alias('throttle.transformer', TransformerFactoryInterface::class);
     }
 
     /**

--- a/src/Transformers/TransformerFactoryInterface.php
+++ b/src/Transformers/TransformerFactoryInterface.php
@@ -11,15 +11,12 @@
 
 namespace GrahamCampbell\Throttle\Transformers;
 
-use Illuminate\Http\Request;
-use InvalidArgumentException;
-
 /**
- * This is the transformer factory class.
+ * This is the transformer factory interface.
  *
  * @author Graham Campbell <graham@alt-three.com>
  */
-class TransformerFactory implements TransformerFactoryInterface
+interface TransformerFactoryInterface
 {
     /**
      * Make a new transformer instance.
@@ -30,16 +27,5 @@ class TransformerFactory implements TransformerFactoryInterface
      *
      * @return \GrahamCampbell\Throttle\Transformers\TransformerInterface
      */
-    public function make($data)
-    {
-        if (is_object($data) && $data instanceof Request) {
-            return new RequestTransformer();
-        }
-
-        if (is_array($data)) {
-            return new ArrayTransformer();
-        }
-
-        throw new InvalidArgumentException('An array, or an instance of Illuminate\Http\Request was expected.');
-    }
+    public function make($data);
 }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -16,7 +16,7 @@ use GrahamCampbell\Throttle\Factories\CacheFactory;
 use GrahamCampbell\Throttle\Factories\FactoryInterface;
 use GrahamCampbell\Throttle\Http\Middleware\ThrottleMiddleware;
 use GrahamCampbell\Throttle\Throttle;
-use GrahamCampbell\Throttle\Transformers\TransformerFactory;
+use GrahamCampbell\Throttle\Transformers\TransformerFactoryInterface;
 
 /**
  * This is the service provider test class.
@@ -35,7 +35,7 @@ class ServiceProviderTest extends AbstractTestCase
 
     public function testTransformerFactoryIsInjectable()
     {
-        $this->assertIsInjectable(TransformerFactory::class);
+        $this->assertIsInjectable(TransformerFactoryInterface::class);
     }
 
     public function testThrottleIsInjectable()

--- a/tests/ThrottleTest.php
+++ b/tests/ThrottleTest.php
@@ -17,7 +17,7 @@ use GrahamCampbell\Throttle\Factories\CacheFactory;
 use GrahamCampbell\Throttle\Throttle;
 use GrahamCampbell\Throttle\Throttlers\CacheThrottler;
 use GrahamCampbell\Throttle\Transformers\ArrayTransformer;
-use GrahamCampbell\Throttle\Transformers\TransformerFactory;
+use GrahamCampbell\Throttle\Transformers\TransformerFactoryInterface;
 use Mockery;
 
 /**
@@ -67,7 +67,7 @@ class ThrottleTest extends AbstractTestBenchTestCase
 
         $trans = Mockery::mock(ArrayTransformer::class);
 
-        $transformer = Mockery::mock(TransformerFactory::class);
+        $transformer = Mockery::mock(TransformerFactoryInterface::class);
 
         $transformer->shouldReceive('make')->with($data)->andReturn($trans);
         $trans->shouldReceive('transform')->with($data, 12, 123)


### PR DESCRIPTION
…pt Interface instead of TransformerFactory

`TransformerFactoryInterface` is created and in case we want to create another `TransformerFactory` and inject it into Throttle class.

Current `TransformerFactory` can only return `ArrayTransformer` or `RequestTransformer`, and it is not replacable.

Another approach could be to create a strategy and allow `TransformerFactory` to return any `TransformerInterface` via container. 

We can discuss what is a better approach to make Transformers replaceable. 

If you ask me "Why we want another Transformers", I could say that in some cases we do not want to count by IP address, we might want to track users by own id. At the moment both transformers are able to create Data object based on IP address and route.

This is just one step to make this package more extensible.