### PR TITLE
Implement DataInterface and allow passing concrete instance directly to Throttle get method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Laravel Throttle was created by, and is maintained by [Graham Campbell](https://
 <a href="https://travis-ci.org/GrahamCampbell/Laravel-Throttle"><img src="https://img.shields.io/travis/GrahamCampbell/Laravel-Throttle/master.svg?style=flat-square" alt="Build Status"></img></a>
 <a href="https://scrutinizer-ci.com/g/GrahamCampbell/Laravel-Throttle/code-structure"><img src="https://img.shields.io/scrutinizer/coverage/g/GrahamCampbell/Laravel-Throttle.svg?style=flat-square" alt="Coverage Status"></img></a>
 <a href="https://scrutinizer-ci.com/g/GrahamCampbell/Laravel-Throttle"><img src="https://img.shields.io/scrutinizer/g/GrahamCampbell/Laravel-Throttle.svg?style=flat-square" alt="Quality Score"></img></a>
+<a href="https://scrutinizer-ci.com/g/GrahamCampbell/Laravel-Throttle"><img src="https://img.shields.io/scrutinizer/g/GrahamCampbell/Laravel-Throttle.svg?style=flat-square" alt="Quality Score"></img></a>
 <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square" alt="Software License"></img></a>
 <a href="https://github.com/GrahamCampbell/Laravel-Throttle/releases"><img src="https://img.shields.io/github/release/GrahamCampbell/Laravel-Throttle.svg?style=flat-square" alt="Latest Version"></img></a>
 </p>
@@ -53,13 +54,28 @@ This option (`'driver'`) defines the cache driver to be used. It may be the name
 
 ## Usage
 
+
+##### DataInterface
+
+This interface defines the public methods a data class must implement. All 3 methods here accept no parameters.
+
+The `'getLimit'` method will return an `int` which represents the maximum number of hits that are allowed before the user hits the limit.
+
+The `'getTime'` method will return an `int` which represents the time the user must wait after going over the limit before the hit count will be reset to zero.
+
+The `'getKey'` method will return a `string` which is used as a unique key to identify the data between requests.
+
+##### Data
+
+This class implements `DataInterface` fully, allowing the throttler to identify repeat calls to `'attempt'`, `'hit'`, `'clear'`, `'count'`, and `'check'`. These are all documented below. 
+
 ##### Throttle
 
 This is the class of most interest. It is bound to the ioc container as `'throttle'` and can be accessed using the `Facades\Throttle` facade. There are six public methods of interest.
 
-The `'get'` method will create a new throttler class (a class that implements `Throttler\ThrottlerInterface`) from the 1-3 parameters that you pass to it. The first parameter is required and must either an instance of `\Illuminate\Http\Request`, or an associative array with two keys (`'ip'` should be the ip address of the user you wish to throttle and `'route'` should be the full url you wish to throttle, but actually, for advanced usage, may be any unique key you choose). The second parameter is optional and should be an `int` which represents the maximum number of hits that are allowed before the user hits the limit. The third and final parameter should be an `int` that represents the time the user must wait after going over the limit before the hit count will be reset to zero. Under the hood this method will be calling the make method on a throttler factory class (a class that implements `Factories\FactoryInterface`).
+The `'get'` method will create a new throttler class (a class that implements `Throttler\ThrottlerInterface`) from the 1-3 parameters that you pass to it. The first parameter is required and must either an instance of `\Illuminate\Http\Request`, an associative array with two keys (`'ip'` should be the ip address of the user you wish to throttle and `'route'` should be the full url you wish to throttle, but actually, for advanced usage, may be any unique key you choose) or an concrete instance of DataInterface. The second parameter is optional and should be an `int` which represents the maximum number of hits that are allowed before the user hits the limit. The third and final parameter should be an `int` that represents the time the user must wait after going over the limit before the hit count will be reset to zero. Under the hood this method will be calling the make method on a throttler factory class (a class that implements `Factories\FactoryInterface`).
 
-The other 5 methods all accept the same parameters as the `get` method. What happens here is we dynamically create a throttler class (or we automatically reuse an instance we already created), and then we call the method on it with no parameters. These 5 methods are `'attempt'`, `'hit'`, `'clear'`, `'count'`, and `'check'`. They are all documented bellow.
+The other 5 methods all accept the same parameters as the `get` method. What happens here is we dynamically create a throttler class (or we automatically reuse an instance we already created), and then we call the method on it with no parameters. These 5 methods are `'attempt'`, `'hit'`, `'clear'`, `'count'`, and `'check'`. They are all documented below.
 
 ##### Facades\Throttle
 

--- a/src/Data.php
+++ b/src/Data.php
@@ -16,7 +16,7 @@ namespace GrahamCampbell\Throttle;
  *
  * @author Graham Campbell <graham@alt-three.com>
  */
-class Data
+class Data implements DataInterface
 {
     /**
      * The ip.

--- a/src/DataInterface.php
+++ b/src/DataInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Laravel Throttle.
+ *
+ * (c) Graham Campbell <graham@alt-three.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace GrahamCampbell\Throttle;
+
+/**
+ * This is the data interface.
+ *
+ * @author Matt Beale <matt@heyratfans.co.uk>
+ */
+interface DataInterface
+{
+    /**
+     * Get the request limit.
+     *
+     * @return int
+     */
+    public function getLimit();
+
+    /**
+     * Get the expiration time.
+     *
+     * @return int
+     */
+    public function getTime();
+
+    /**
+     * Get the unique key.
+     *
+     * This key is used to identify the data between requests.
+     *
+     * @return string
+     */
+    public function getKey();
+}

--- a/src/Factories/CacheFactory.php
+++ b/src/Factories/CacheFactory.php
@@ -11,7 +11,7 @@
 
 namespace GrahamCampbell\Throttle\Factories;
 
-use GrahamCampbell\Throttle\Data;
+use GrahamCampbell\Throttle\DataInterface;
 use GrahamCampbell\Throttle\Throttlers\CacheThrottler;
 use Illuminate\Contracts\Cache\Repository;
 
@@ -44,11 +44,11 @@ class CacheFactory implements FactoryInterface
     /**
      * Make a new cache throttler instance.
      *
-     * @param \GrahamCampbell\Throttle\Data $data
+     * @param \GrahamCampbell\Throttle\DataInterface $data
      *
      * @return \GrahamCampbell\Throttle\Throttlers\CacheThrottler
      */
-    public function make(Data $data)
+    public function make(DataInterface $data)
     {
         return new CacheThrottler($this->cache->getStore(), $data->getKey(), $data->getLimit(), $data->getTime());
     }

--- a/src/Factories/FactoryInterface.php
+++ b/src/Factories/FactoryInterface.php
@@ -11,7 +11,7 @@
 
 namespace GrahamCampbell\Throttle\Factories;
 
-use GrahamCampbell\Throttle\Data;
+use GrahamCampbell\Throttle\DataInterface;
 
 /**
  * This is the throttler factory interface.
@@ -23,9 +23,9 @@ interface FactoryInterface
     /**
      * Make a new throttler instance.
      *
-     * @param \GrahamCampbell\Throttle\Data $data
+     * @param \GrahamCampbell\Throttle\DataInterface $data
      *
      * @return \GrahamCampbell\Throttle\Throttlers\ThrottlerInterface
      */
-    public function make(Data $data);
+    public function make(DataInterface $data);
 }

--- a/src/Throttle.php
+++ b/src/Throttle.php
@@ -65,18 +65,20 @@ class Throttle
     /**
      * Get a new throttler.
      *
-     * @param array|\Illuminate\Http\Request $data
-     * @param int                            $limit
-     * @param int                            $time
+     * @param array|\Illuminate\Http\Request|\GrahamCampbell\Throttle\DataInterface $data
+     * @param int                                                                   $limit
+     * @param int                                                                   $time
      *
      * @return \GrahamCampbell\Throttle\Throttlers\ThrottlerInterface
      */
     public function get($data, $limit = 10, $time = 60)
     {
-        $transformed = $this->transformer->make($data)->transform($data, $limit, $time);
+        if (!($data instanceof DataInterface)) {
+            $data = $this->transformer->make($data)->transform($data, $limit, $time);
+        }
 
-        if (!array_key_exists($key = $transformed->getKey(), $this->throttlers)) {
-            $this->throttlers[$key] = $this->factory->make($transformed);
+        if (!array_key_exists($key = $data->getKey(), $this->throttlers)) {
+            $this->throttlers[$key] = $this->factory->make($data);
         }
 
         return $this->throttlers[$key];

--- a/src/Transformers/ArrayTransformer.php
+++ b/src/Transformers/ArrayTransformer.php
@@ -30,7 +30,7 @@ class ArrayTransformer implements TransformerInterface
      *
      * @throws \InvalidArgumentException
      *
-     * @return \GrahamCampbell\Throttle\Data
+     * @return \GrahamCampbell\Throttle\DataInterface
      */
     public function transform($data, $limit = 10, $time = 60)
     {

--- a/src/Transformers/RequestTransformer.php
+++ b/src/Transformers/RequestTransformer.php
@@ -27,7 +27,7 @@ class RequestTransformer implements TransformerInterface
      * @param int                      $limit
      * @param int                      $time
      *
-     * @return \GrahamCampbell\Throttle\Data
+     * @return \GrahamCampbell\Throttle\DataInterface
      */
     public function transform($data, $limit = 10, $time = 60)
     {

--- a/src/Transformers/TransformerInterface.php
+++ b/src/Transformers/TransformerInterface.php
@@ -25,7 +25,7 @@ interface TransformerInterface
      * @param int                            $limit
      * @param int                            $time
      *
-     * @return \GrahamCampbell\Throttle\Data
+     * @return \GrahamCampbell\Throttle\DataInterface
      */
     public function transform($data, $limit = 10, $time = 60);
 }

--- a/tests/Factories/CacheFactoryTest.php
+++ b/tests/Factories/CacheFactoryTest.php
@@ -12,7 +12,7 @@
 namespace GrahamCampbell\Tests\Throttle\Factories;
 
 use GrahamCampbell\TestBench\AbstractTestCase;
-use GrahamCampbell\Throttle\Data;
+use GrahamCampbell\Throttle\DataInterface;
 use GrahamCampbell\Throttle\Factories\CacheFactory;
 use GrahamCampbell\Throttle\Throttlers\CacheThrottler;
 use Illuminate\Contracts\Cache\Repository;
@@ -33,7 +33,7 @@ class CacheFactoryTest extends AbstractTestCase
         $throttle->getCache()->shouldReceive('getStore')
             ->once()->andReturn(Mockery::mock(Store::class));
 
-        $data = Mockery::mock(Data::class);
+        $data = Mockery::mock(DataInterface::class);
         $data->shouldReceive('getKey')->once()->andReturn('unique-hash');
         $data->shouldReceive('getLimit')->once()->andReturn(246);
         $data->shouldReceive('getTime')->once()->andReturn(123);

--- a/tests/Transformers/TransformerFactoryTest.php
+++ b/tests/Transformers/TransformerFactoryTest.php
@@ -12,7 +12,7 @@
 namespace GrahamCampbell\Tests\Throttle\Transformers;
 
 use GrahamCampbell\TestBench\AbstractTestCase;
-use GrahamCampbell\Throttle\Data;
+use GrahamCampbell\Throttle\DataInterface;
 use GrahamCampbell\Throttle\Transformers\ArrayTransformer;
 use GrahamCampbell\Throttle\Transformers\RequestTransformer;
 use GrahamCampbell\Throttle\Transformers\TransformerFactory;
@@ -36,7 +36,7 @@ class TransformerFactoryTest extends AbstractTestCase
         $request->shouldReceive('getClientIp')->once()->andReturn('123.123.123.123');
         $request->shouldReceive('path')->once()->andReturn('foobar');
 
-        $this->assertInstanceOf(Data::class, $transformer->transform($request, 123, 321));
+        $this->assertInstanceOf(DataInterface::class, $transformer->transform($request, 123, 321));
     }
 
     public function testArray()
@@ -46,7 +46,7 @@ class TransformerFactoryTest extends AbstractTestCase
 
         $this->assertInstanceOf(ArrayTransformer::class, $transformer);
 
-        $this->assertInstanceOf(Data::class, $transformer->transform($array, 123, 321));
+        $this->assertInstanceOf(DataInterface::class, $transformer->transform($array, 123, 321));
     }
 
     /**
@@ -60,7 +60,7 @@ class TransformerFactoryTest extends AbstractTestCase
 
         $this->assertInstanceOf(ArrayTransformer::class, $transformer);
 
-        $this->assertInstanceOf(Data::class, $transformer->transform([]));
+        $this->assertInstanceOf(DataInterface::class, $transformer->transform([]));
     }
 
     /**


### PR DESCRIPTION
Adds more flexibility to Laravel-Throttle by allowing custom `DataInterface` implementations to be passed to Throttle::get instead of the `$data` argument having to be a Laravel Request or an array with keys 'ip' and 'route'. We use this to apply a throttle based on the id of the currently authenticated user. 

We know this was already technically possibly using the ArrayTransformer and specifying the user's id (or other custom data) as either the 'ip' or 'route' keys, but it felt "hacky" specifying the "wrong" values for those array keys and we didn't want other developers on our team getting confused by us having done this.

Of course, this doesn't work with the Middleware, but never expected it to.