### PR TITLE
[For 6.x] Adds redis atomic hit impl.

### DIFF
--- a/src/Throttlers/CacheThrottler.php
+++ b/src/Throttlers/CacheThrottler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace GrahamCampbell\Throttle\Throttlers;
 
 use Countable;
+use Illuminate\Cache\RedisStore;
 use Illuminate\Contracts\Cache\Store;
 
 /**
@@ -97,6 +98,10 @@ class CacheThrottler implements ThrottlerInterface, Countable
      */
     public function hit()
     {
+        if ($this->store instanceof RedisStore) {
+            return $this->hitRedis();
+        }
+
         if ($this->count()) {
             $this->store->increment($this->key);
             $this->number++;
@@ -160,5 +165,31 @@ class CacheThrottler implements ThrottlerInterface, Countable
     public function getStore()
     {
         return $this->store;
+    }
+
+    /**
+     * An atomic hit implementation for redis.
+     *
+     * @return $this
+     */
+    protected function hitRedis()
+    {
+        $lua = 'local v = redis.call(\'incr\', KEYS[1]) '.
+               'if v>1 then return v '.
+               'else redis.call(\'setex\', KEYS[1], ARGV[1], 1) return 1 end';
+
+        $this->number = $this->store->connection()->eval($lua, 1, $this->computeRedisKey(), $this->time * 60);
+
+        return $this;
+    }
+
+    /**
+     * Compute the cache key for redis.
+     *
+     * @return string
+     */
+    protected function computeRedisKey()
+    {
+        return $this->store->getPrefix().$this->key;
     }
 }


### PR DESCRIPTION
__Context__

- https://github.com/GrahamCampbell/Laravel-Throttle/pull/74
- Unfortunately, we are using 6.x (still on laravel 5.4 and no plan to do migration in near months :( )

@GrahamCampbell : Please see if this is acceptable for 6.x. (Cherry-picked earlier 3 commits and amended into 1.)