### PR TITLE
Added ttl method

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ The `'clear'` method will clear the throttle (set the hit count to zero), and th
 
 The `'count'` method will return the number of hits to the throttle.
 
+The `'ttl'` method will return the time until the end of the current duration in seconds.
+
 The `'check'` method will return a boolean representing whether or not the hit limit has been exceeded.
 
 ##### Throttler\CacheThrottler

--- a/src/Throttlers/CacheThrottler.php
+++ b/src/Throttlers/CacheThrottler.php
@@ -155,7 +155,7 @@ class CacheThrottler implements ThrottlerInterface, Countable
     public function ttl()
     {
         if (!$this->store instanceof RedisStore) {
-            throw new \LogicException('The ttl() method can only be called for Redis backed throttlers');
+            return -1;
         }
 
         return $this->store->connection()->ttl($this->computeRedisKey());

--- a/src/Throttlers/CacheThrottler.php
+++ b/src/Throttlers/CacheThrottler.php
@@ -148,6 +148,20 @@ class CacheThrottler implements ThrottlerInterface, Countable
     }
 
     /**
+     * Get the time until the end of current duration.
+     *
+     * @return int
+     */
+    public function ttl()
+    {
+        if (!$this->store instanceof RedisStore) {
+            throw new \LogicException('The ttl() method can only be called for Redis backed throttlers');
+        }
+
+        return $this->store->connection()->ttl($this->computeRedisKey());
+    }
+
+    /**
      * Check the throttle.
      *
      * @return bool

--- a/src/Throttlers/ThrottlerInterface.php
+++ b/src/Throttlers/ThrottlerInterface.php
@@ -49,6 +49,13 @@ interface ThrottlerInterface
     public function count();
 
     /**
+     * Get the time until the end of current duration.
+     *
+     * @return int
+     */
+    public function ttl();
+
+    /**
      * Check the throttle.
      *
      * @return bool


### PR DESCRIPTION
Hi there 👋 I've added a method to check for the end of the current duration. This way you will be able to add all standard rate-limit headers (X-RateLimit-Limit, X-RateLimit-Remaining, and X-RateLimit-Reset). It would be great if each Laravel cache implementation handles such functionality, but for now this is the best we can do. Hopefully you like it 😄
