### PR TITLE
accept time as float number

### DIFF
--- a/.idea/deployment.xml
+++ b/.idea/deployment.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PublishConfigData" persistUploadOnCheckin="false" />
+</project>

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "graham-campbell/throttle",
+    "name": "retnek/laravel-throttle",
     "description": "Throttle Is A Rate Limiter For Laravel 5",
     "keywords": ["laravel", "framework", "rate limit", "throttle", "throttling", "Throttle", "Laravel Throttle", "Laravel-Throttle", "Graham Campbell", "GrahamCampbell"],
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "retnek/laravel-throttle",
+    "name": "graham-campbell/throttle",
     "description": "Throttle Is A Rate Limiter For Laravel 5",
     "keywords": ["laravel", "framework", "rate limit", "throttle", "throttling", "Throttle", "Laravel Throttle", "Laravel-Throttle", "Graham Campbell", "GrahamCampbell"],
     "license": "MIT",

--- a/src/Data.php
+++ b/src/Data.php
@@ -61,11 +61,11 @@ class Data
      * @param string $ip
      * @param string $route
      * @param int    $limit
-     * @param int    $time
+     * @param float  $time
      *
      * @return void
      */
-    public function __construct(string $ip, string $route, int $limit = 10, int $time = 60)
+    public function __construct(string $ip, string $route, int $limit = 10, float $time = 60)
     {
         $this->ip = $ip;
         $this->route = $route;

--- a/src/Http/Middleware/ThrottleMiddleware.php
+++ b/src/Http/Middleware/ThrottleMiddleware.php
@@ -49,7 +49,7 @@ class ThrottleMiddleware
      * @param \Illuminate\Http\Request $request
      * @param \Closure                 $next
      * @param int                      $limit
-     * @param int                      $time
+     * @param float                    $time
      *
      * @throws \Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException
      *
@@ -57,7 +57,7 @@ class ThrottleMiddleware
      */
     public function handle($request, Closure $next, $limit = 10, $time = 60)
     {
-        if (!$this->throttle->attempt($request, (int) $limit, (int) $time)) {
+        if (!$this->throttle->attempt($request, (int) $limit, (float) $time)) {
             throw new TooManyRequestsHttpException($time * 60, 'Rate limit exceeded.');
         }
 

--- a/src/Throttle.php
+++ b/src/Throttle.php
@@ -69,11 +69,11 @@ class Throttle
      *
      * @param mixed $data
      * @param int   $limit
-     * @param int   $time
+     * @param float $time
      *
      * @return \GrahamCampbell\Throttle\Throttlers\ThrottlerInterface
      */
-    public function get($data, int $limit = 10, int $time = 60)
+    public function get($data, int $limit = 10, float $time = 60)
     {
         $transformed = $this->transformer->make($data)->transform($data, $limit, $time);
 

--- a/src/Throttle.php
+++ b/src/Throttle.php
@@ -19,9 +19,9 @@ use GrahamCampbell\Throttle\Transformers\TransformerFactoryInterface;
 /**
  * This is the throttle class.
  *
- * @method bool attempt(array|\Illuminate\Http\Request $data, int $limit, int $time)
- * @method \GrahamCampbell\Throttle\Throttlers\ThrottlerInterface hit(array|\Illuminate\Http\Request $data, int $limit, int $time)
- * @method \GrahamCampbell\Throttle\Throttlers\ThrottlerInterface clear(array|\Illuminate\Http\Request $data, int $limit, int $time)
+ * @method bool attempt(array|\Illuminate\Http\Request $data, int $limit, float $time)
+ * @method \GrahamCampbell\Throttle\Throttlers\ThrottlerInterface hit(array|\Illuminate\Http\Request $data, int $limit, float $time)
+ * @method \GrahamCampbell\Throttle\Throttlers\ThrottlerInterface clear(array|\Illuminate\Http\Request $data, int $limit, float $time)
  * @method int count(array|\Illuminate\Http\Request $data, int $limit, int $time)
  * @method bool check(array|\Illuminate\Http\Request $data, int $limit, int $time)
  *

--- a/src/Throttlers/CacheThrottler.php
+++ b/src/Throttlers/CacheThrottler.php
@@ -48,7 +48,7 @@ class CacheThrottler implements ThrottlerInterface, Countable
     /**
      * The expiration time.
      *
-     * @var int
+     * @var float
      */
     protected $time;
 
@@ -65,11 +65,11 @@ class CacheThrottler implements ThrottlerInterface, Countable
      * @param \Illuminate\Contracts\Cache\Store $store
      * @param string                            $key
      * @param int                               $limit
-     * @param int                               $time
+     * @param float                             $time
      *
      * @return void
      */
-    public function __construct(Store $store, string $key, int $limit, int $time)
+    public function __construct(Store $store, string $key, int $limit, float $time)
     {
         $this->store = $store;
         $this->key = $key;

--- a/src/Transformers/ArrayTransformer.php
+++ b/src/Transformers/ArrayTransformer.php
@@ -28,13 +28,13 @@ class ArrayTransformer implements TransformerInterface
      *
      * @param array $data
      * @param int   $limit
-     * @param int   $time
+     * @param float $time
      *
      * @throws \InvalidArgumentException
      *
      * @return \GrahamCampbell\Throttle\Data
      */
-    public function transform($data, int $limit = 10, int $time = 60)
+    public function transform($data, int $limit = 10, float $time = 60)
     {
         if (($ip = array_get($data, 'ip')) && ($route = array_get($data, 'route'))) {
             return new Data((string) $ip, (string) $route, (int) $limit, (int) $time);

--- a/src/Transformers/ArrayTransformer.php
+++ b/src/Transformers/ArrayTransformer.php
@@ -37,7 +37,7 @@ class ArrayTransformer implements TransformerInterface
     public function transform($data, int $limit = 10, float $time = 60)
     {
         if (($ip = array_get($data, 'ip')) && ($route = array_get($data, 'route'))) {
-            return new Data((string) $ip, (string) $route, (int) $limit, (int) $time);
+            return new Data((string) $ip, (string) $route, $limit, $time);
         }
 
         throw new InvalidArgumentException('The data array does not provide the required ip and route information.');

--- a/src/Transformers/RequestTransformer.php
+++ b/src/Transformers/RequestTransformer.php
@@ -27,11 +27,11 @@ class RequestTransformer implements TransformerInterface
      *
      * @param \Illuminate\Http\Request $data
      * @param int                      $limit
-     * @param int                      $time
+     * @param float                    $time
      *
      * @return \GrahamCampbell\Throttle\Data
      */
-    public function transform($data, int $limit = 10, int $time = 60)
+    public function transform($data, int $limit = 10, float $time = 60)
     {
         return new Data((string) $data->getClientIp(), (string) $data->path(), (int) $limit, (int) $time);
     }

--- a/src/Transformers/RequestTransformer.php
+++ b/src/Transformers/RequestTransformer.php
@@ -33,6 +33,6 @@ class RequestTransformer implements TransformerInterface
      */
     public function transform($data, int $limit = 10, float $time = 60)
     {
-        return new Data((string) $data->getClientIp(), (string) $data->path(), (int) $limit, (int) $time);
+        return new Data((string) $data->getClientIp(), (string) $data->path(), $limit, $time);
     }
 }

--- a/src/Transformers/TransformerInterface.php
+++ b/src/Transformers/TransformerInterface.php
@@ -25,9 +25,9 @@ interface TransformerInterface
      *
      * @param array|\Illuminate\Http\Request $data
      * @param int                            $limit
-     * @param int                            $time
+     * @param float                          $time
      *
      * @return \GrahamCampbell\Throttle\Data
      */
-    public function transform($data, int $limit = 10, int $time = 60);
+    public function transform($data, int $limit = 10, float $time = 60);
 }

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -48,7 +48,7 @@ class DataTest extends AbstractTestBenchTestCase
     {
         $data = $this->getData();
 
-        $this->assertSame(321, $data->getTime());
+        $this->assertSame(321.0, $data->getTime());
     }
 
     public function testGetKey()

--- a/tests/Throttlers/CacheThrottlerTest.php
+++ b/tests/Throttlers/CacheThrottlerTest.php
@@ -30,7 +30,7 @@ class CacheThrottlerTest extends AbstractTestCase
         $throttler = $this->getThrottler();
 
         $throttler->getStore()->shouldReceive('get')->once()->with('abc');
-        $throttler->getStore()->shouldReceive('put')->once()->with('abc', 1, 60);
+        $throttler->getStore()->shouldReceive('put')->once()->with('abc', 1, 60.5);
 
         $return = $throttler->attempt();
 
@@ -42,7 +42,7 @@ class CacheThrottlerTest extends AbstractTestCase
         $throttler = $this->getThrottler();
 
         $throttler->getStore()->shouldReceive('get')->once()->with('abc');
-        $throttler->getStore()->shouldReceive('put')->once()->with('abc', 1, 60);
+        $throttler->getStore()->shouldReceive('put')->once()->with('abc', 1, 60.5);
 
         $return = $throttler->hit();
 
@@ -57,7 +57,7 @@ class CacheThrottlerTest extends AbstractTestCase
     {
         $throttler = $this->getThrottler();
 
-        $throttler->getStore()->shouldReceive('put')->once()->with('abc', 0, 60);
+        $throttler->getStore()->shouldReceive('put')->once()->with('abc', 0, 60.5);
 
         $return = $throttler->clear();
 
@@ -128,7 +128,7 @@ class CacheThrottlerTest extends AbstractTestCase
         $store = Mockery::mock(Store::class);
         $key = 'abc';
         $limit = 10;
-        $time = 60;
+        $time = 60.5;
 
         return new CacheThrottler($store, $key, $limit, $time);
     }


### PR DESCRIPTION
If we force integer data type (by type hints) we don't allow to set retention time as seconds.
The Laravel's Store interface already accepts time as float, so I changed time's data type to float in all necessary places.

ref to #82 